### PR TITLE
:sparkle: add topological sort to graph lib (closes #43)

### DIFF
--- a/src/main/scala/org/lemon/advent/lib/graph/topological.scala
+++ b/src/main/scala/org/lemon/advent/lib/graph/topological.scala
@@ -1,0 +1,50 @@
+package org.lemon.advent.lib.graph
+
+import scala.collection.mutable
+
+/** Performs a [topological sort](https://en.wikipedia.org/wiki/Topological_sorting) of the
+  * directed graph using [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
+  * Returns an ordering of the given nodes such that for every edge `u -> v` returned by
+  * `adjacency`, `u` appears before `v` in the result. Edges to nodes outside of `nodes`
+  * are ignored, which makes it convenient to topologically sort a subset of a larger graph.
+  *
+  * If the graph (restricted to `nodes`) contains a cycle, no valid ordering exists and `None`
+  * is returned. The ordering is otherwise deterministic and biased towards the iteration order
+  * of `nodes`: when multiple nodes have no remaining prerequisites, the one that appeared
+  * first in `nodes` is emitted first.
+  *
+  * @param nodes the nodes to include in the ordering
+  * @param adjacency function returning the nodes that must come *after* the given node
+  * @return an ordering of `nodes` consistent with `adjacency`, or `None` if a cycle exists
+  * @tparam N the node type
+  */
+def topologicalSort[N](nodes: Iterable[N], adjacency: N => Iterable[N] | Iterator[N]): Option[Seq[N]] =
+  val ordered = nodes.iterator.distinct.toVector
+  val nodeSet = ordered.toSet
+  val inDegree = mutable.LinkedHashMap.from(ordered.iterator.map(_ -> 0))
+  for node <- ordered; neighbour <- adjacency(node) if nodeSet.contains(neighbour) do
+    inDegree(neighbour) += 1
+  val queue = mutable.Queue.from(ordered.filter(inDegree(_) == 0))
+  val result = Vector.newBuilder[N]
+  while queue.nonEmpty do
+    val node = queue.dequeue()
+    result += node
+    for neighbour <- adjacency(node) if nodeSet.contains(neighbour) do
+      inDegree(neighbour) -= 1
+      if inDegree(neighbour) == 0 then queue.enqueue(neighbour)
+  val sorted = result.result()
+  Option.when(sorted.size == ordered.size)(sorted)
+
+/** Performs a [topological sort](https://en.wikipedia.org/wiki/Topological_sorting) of the
+  * directed graph using [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
+  * Returns an ordering of all the nodes in `graph` such that for every edge `u -> v`,
+  * `u` appears before `v` in the result.
+  *
+  * If the graph contains a cycle, no valid ordering exists and `None` is returned.
+  *
+  * @param graph the graph as an adjacency list
+  * @return an ordering of the nodes in `graph` consistent with the edges, or `None` if a cycle exists
+  * @tparam N the node type
+  */
+def topologicalSort[N](graph: UnitGraph[N]): Option[Seq[N]] =
+  topologicalSort(graph.keys, graph.withDefaultValue(Iterable.empty))

--- a/src/main/scala/org/lemon/advent/year2024/Day05.scala
+++ b/src/main/scala/org/lemon/advent/year2024/Day05.scala
@@ -1,6 +1,7 @@
 package org.lemon.advent.year2024
 
 import org.lemon.advent.lib.*
+import org.lemon.advent.lib.graph.*
 
 private object Day05:
 
@@ -12,23 +13,22 @@ private object Day05:
     val p = pages.linesIterator.map(_.csv.map(_.toInt)).toSeq
     (r, p)
 
-  @annotation.tailrec
-  def isOrdered(pages: Seq[Int], rules: Seq[Rule]): Boolean =
-    if rules.isEmpty then true
-    else
-      val rule = rules.head
-      val before = pages.indexOf(rule.before)
-      val after = pages.indexOf(rule.after)
-      if before < 0 || after < 0 || before < after then isOrdered(pages, rules.tail)
-      else false
+  /** Topologically sorts the pages according to the rules that apply to them. */
+  def order(pages: Seq[Int], rules: Seq[Rule]): Seq[Int] =
+    val pageSet = pages.toSet
+    val adjacency = rules
+      .filter(r => pageSet.contains(r.before) && pageSet.contains(r.after))
+      .groupMap(_.before)(_.after)
+      .withDefaultValue(Seq.empty)
+    topologicalSort(pages, adjacency).get
 
   def part1(input: String) =
     val (rules, pages) = parse(input)
-    pages.filter(isOrdered(_, rules)).map(p => p(p.size / 2)).sum
-
-  def fixOrder(pages: Seq[Int], rules: Seq[Rule]): Seq[Int] =
-    pages.sortWith((a, b) => rules.exists(r => r.before == a && r.after == b))
+    pages.filter(p => order(p, rules) == p).map(p => p(p.size / 2)).sum
 
   def part2(input: String) =
     val (rules, pages) = parse(input)
-    pages.filterNot(isOrdered(_, rules)).map(fixOrder(_, rules)).map(p => p(p.size / 2)).sum
+    pages.flatMap { p =>
+      val sorted = order(p, rules)
+      Option.when(sorted != p)(sorted(sorted.size / 2))
+    }.sum

--- a/src/test/scala/org/lemon/advent/lib/graph/TopologicalTest.scala
+++ b/src/test/scala/org/lemon/advent/lib/graph/TopologicalTest.scala
@@ -1,0 +1,106 @@
+package org.lemon.advent.lib.graph
+
+import org.lemon.advent.*
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+
+class TopologicalTest extends UnitTest:
+
+  test("empty graph yields empty ordering") {
+    topologicalSort(Map.empty[Int, Iterable[Int]]) shouldBe Some(Seq.empty[Int])
+  }
+
+  test("single node with no edges") {
+    topologicalSort(Map(1 -> Seq.empty[Int])) shouldBe Some(Seq(1))
+  }
+
+  test("simple linear chain is sorted in dependency order") {
+    val graph = Map(1 -> Seq(2), 2 -> Seq(3), 3 -> Seq(4), 4 -> Seq.empty[Int])
+    topologicalSort(graph) shouldBe Some(Seq(1, 2, 3, 4))
+  }
+
+  test("respects iteration order when nodes have no edges") {
+    val nodes = Seq(3, 1, 2, 4)
+    topologicalSort(nodes, _ => Seq.empty[Int]) shouldBe Some(Seq(3, 1, 2, 4))
+  }
+
+  test("diamond shape produces a valid ordering") {
+    // 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4
+    val graph = Map(1 -> Seq(2, 3), 2 -> Seq(4), 3 -> Seq(4), 4 -> Seq.empty[Int])
+    val sorted = topologicalSort(graph).get
+    sorted should contain theSameElementsAs Seq(1, 2, 3, 4)
+    sorted.indexOf(1) should be < sorted.indexOf(2)
+    sorted.indexOf(1) should be < sorted.indexOf(3)
+    sorted.indexOf(2) should be < sorted.indexOf(4)
+    sorted.indexOf(3) should be < sorted.indexOf(4)
+  }
+
+  test("simple cycle returns None") {
+    val graph = Map(1 -> Seq(2), 2 -> Seq(3), 3 -> Seq(1))
+    topologicalSort(graph) shouldBe None
+  }
+
+  test("self loop returns None") {
+    val graph = Map(1 -> Seq(1))
+    topologicalSort(graph) shouldBe None
+  }
+
+  test("ignores edges to nodes outside the requested subset") {
+    // graph: 1 -> 2 -> 3, but only ask for {1, 3} — 1 has no in-graph successor
+    val adjacency: Int => Seq[Int] = Map(1 -> Seq(2), 2 -> Seq(3), 3 -> Seq.empty)
+    val sorted = topologicalSort(Seq(1, 3), adjacency).get
+    sorted should contain theSameElementsAs Seq(1, 3)
+  }
+
+  test("cycle in unrelated subgraph does not affect requested subset") {
+    // 4 <-> 5 cycle exists but we only ask for {1, 2, 3} which is acyclic
+    val adjacency: Int => Seq[Int] =
+      Map(1 -> Seq(2), 2 -> Seq(3), 3 -> Seq.empty, 4 -> Seq(5), 5 -> Seq(4))
+    topologicalSort(Seq(1, 2, 3), adjacency) shouldBe Some(Seq(1, 2, 3))
+  }
+
+  test("duplicate nodes are deduplicated while preserving first-seen order") {
+    val sorted = topologicalSort(Seq(2, 1, 2, 3, 1), (_: Int) => Seq.empty[Int]).get
+    sorted shouldBe Seq(2, 1, 3)
+  }
+
+  test("ordering satisfies every adjacency edge") {
+    val nodeGen = Gen.choose(0, 50)
+    val edgeGen = for
+      a <- nodeGen
+      b <- nodeGen.suchThat(_ != a)
+    yield (a, b)
+    val dagGen = for
+      n <- Gen.choose(0, 30)
+      pairs <- Gen.listOfN(n, edgeGen)
+      // make it acyclic by enforcing edges go from low to high node
+    yield pairs.map { case (a, b) => if a < b then (a, b) else (b, a) }.distinct
+
+    check(forAll(dagGen) { edges =>
+      val nodes = (edges.flatMap { case (a, b) => Seq(a, b) }).distinct
+      val adjacency = edges.groupMap(_._1)(_._2).withDefaultValue(Seq.empty[Int])
+      topologicalSort(nodes, adjacency) match
+        case None => false
+        case Some(sorted) =>
+          sorted.toSet == nodes.toSet &&
+          edges.forall { case (a, b) => sorted.indexOf(a) < sorted.indexOf(b) }
+    })
+  }
+
+  test("any cycle is detected") {
+    // build a guaranteed cycle: a forward chain 0 -> 1 -> ... -> n plus a back-edge n -> 0,
+    // optionally sprinkled with extra forward edges
+    val gen = for
+      n <- Gen.choose(1, 20)
+      extra <- Gen.listOf(for
+        a <- Gen.choose(0, n)
+        b <- Gen.choose(0, n).suchThat(_ != a)
+      yield if a < b then (a, b) else (b, a))
+    yield ((0 until n).map(i => (i, i + 1)) :+ (n, 0)) ++ extra
+
+    check(forAll(gen) { edges =>
+      val nodes = edges.flatMap { case (a, b) => Seq(a, b) }.distinct
+      val adjacency = edges.groupMap(_._1)(_._2).withDefaultValue(Seq.empty[Int])
+      topologicalSort(nodes, adjacency).isEmpty
+    })
+  }


### PR DESCRIPTION
<!-- autobot -->

## Summary
- Adds `topologicalSort` to `org.lemon.advent.lib.graph`, implemented with Kahn's algorithm. Returns `Option[Seq[N]]` (None on cycle), preserves the iteration order of the input nodes for deterministic output, and ignores edges to nodes outside the requested subset so that callers can topo-sort a subgraph.
- Uses the new helper in `year2024.Day05`, replacing the hand-rolled `sortWith` / `isOrdered` pair with `order(pages, rules)` that applies the rules whose endpoints both appear in the current update.
- Adds `TopologicalTest` covering chains, diamonds, cycles, self loops, subgraph isolation, deduplication, and ScalaCheck properties for ordering correctness and cycle detection.

## Original task
address github issue #43

add the library function and use throughout the solutions where appropriate

## Test plan
- [x] `sbt "testOnly org.lemon.advent.lib.graph.TopologicalTest"` (12/12 pass)
- [x] `sbt "testOnly org.lemon.advent.lib.*"` (480/480 pass)
- [x] `sbt "testOnly org.lemon.advent.year2024.Day05Test -- -z example"` (2/2 example tests pass; the non-example "part 1"/"part 2" tests load `day05.txt`, which is git-crypt encrypted and unavailable in this environment)